### PR TITLE
Fix focus mode

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "Chess.com analyse at lichess",
   "description": "Analyse chess.com game at lichess.org for free.",
   "homepage_url": "https://github.com/Zeraye/chess-analysis-firefox-extension/",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "author": "zeraye",
 
   "icons": {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -189,18 +189,13 @@ const analyseGame = async (tab) => {
   try {
     await setLoadingState(true, tab.id);
 
-    const [playerName] = await browser.tabs.executeScript(tab.id, {
-      code: `document.querySelector('[data-test-element="user-tagline-username"]').textContent;`,
+    const [topPlayerName] = await browser.tabs.executeScript(tab.id, {
+      code: `document.querySelector('.user-username-component').textContent;`,
     });
-
-    // get logged in user (needed to flip the board if the logged in user is black)
-    const [loggedInUser] = await browser.tabs.executeScript({
-      code: `document.getElementById('notifications-request')?.getAttribute("username") || null;`,
-    }).catch(console.error);
 
     const gameId = tab.url.split("?")[0];
 
-    let pgn = await getPGN(playerName, gameId, tab.id);
+    let pgn = await getPGN(topPlayerName, gameId, tab.id);
 
     await setLoadingState(false, tab.id);
 
@@ -220,7 +215,7 @@ const analyseGame = async (tab) => {
     let lichessTab = await browser.tabs.create({
       url: "https://lichess.org/paste",
     });
-    await lichessAnalyse(lichessTab.id, pgn, getBlackPlayer(pgn) === loggedInUser);
+    await lichessAnalyse(lichessTab.id, pgn, getBlackPlayer(pgn) !== topPlayerName);
   } catch (error) {
     sendLogMessage(error, tab.id);
   }


### PR DESCRIPTION
Extension wouldn't work when in focus mode (you'd have to exit then click again).

PR fixes that by updating the player name selector to one that is present in both modes (focus & non-focus)

Also updated how `getBlackPlayer` works by checking if the top player is black or white, which should be more maintainable